### PR TITLE
[ci skip] Fix yout terminology and update typos configuration

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -71,3 +71,6 @@ MTK = "MTK"
 ODE = "ODE"
 PDE = "PDE"
 SDE = "SDE"
+
+# DASSL/Fortran-specific terms
+yout = "yout"


### PR DESCRIPTION
## Summary

This PR fixes the handling of yout terminology in DASSL.jl by recognizing it as a legitimate Fortran parameter name rather than a typo.

## Problem

The previous spelling fix PR incorrectly changed yout to your in contexts where yout is actually a legitimate Fortran parameter name used in DASSL documentation and interfaces.

## Changes Made

- Added 'yout' to .typos.toml as legitimate Fortran parameter name

## Context

yout appears to be a standard Fortran parameter name in numerical software, particularly in contexts like:
- Array parameter documentation
- Fortran interface descriptions  
- Mathematical library parameter lists

This is similar to other abbreviated parameter names commonly used in numerical computing.

## Notes

-  included to avoid unnecessary CI runs for terminology fixes
- This corrects the previous overly aggressive spell checking
- Maintains spell checking for actual typos while preserving domain-specific terminology