### PR TITLE
Bump version to 3.2.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DASSL"
 uuid = "e993076c-0cfd-5d6b-a1ac-36489fdf7917"
-version = "3.1.0"
+version = "3.2.0"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 
 [deps]


### PR DESCRIPTION
## What changed and why

Bumps DASSL from 3.1.0 to 3.2.0 to release the restored, explicitly documented SciML common interface from https://github.com/SciML/DASSL.jl/pull/114, together with the already-merged dependency-floor corrections. This is the next consecutive version and follows the minor-bump policy for restored public API in a package at version 1 or later.

Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Verification

- `~/.juliaup/bin/julia +release -m Runic --check .` — exited 0.
- `typos Project.toml` — exited 0 with no findings.
- `GROUP=QA ~/.juliaup/bin/julia +release --project -e 'using Pkg; Pkg.test()'` — `QA/qa.jl | 80 passed / 80 total`; package tests passed.
- `~/.juliaup/bin/julia +release --project -e 'using Pkg; Pkg.test()'` — seven Core testsets, 164 passed / 164 total; package tests passed.

## Not verified

The docs build and downstream/allowed-to-fail jobs were not run locally because this PR changes only the package version.

AI continuation: OpenAI Codex session ID 01a03a11-47c2-77e0-858b-167004f0b79c.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rmh6B9eoW3N8oCbuuVPVxJ