### PR TITLE
Make 32-bit Core lane non-blocking

### DIFF
--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -7,6 +7,7 @@ group = "Core"
 versions = ["1"]
 os = ["ubuntu-latest"]
 arch = "x86"
+continue_on_error = true
 
 [QA]
 versions = ["lts", "1"]


### PR DESCRIPTION
## Summary
- Set `continue_on_error = true` on the `arch = "x86"` Core lane
- Lane already ran and failed on Int32 / dependency issues; keep signal without blocking default-branch CI

## Test plan
- [ ] 32-bit job still schedules
- [ ] Failure does not fail the overall Tests workflow


Made with [Cursor](https://cursor.com)