### PR TITLE
Require Symbolics 7.39.2 (32-bit hasha_seed)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,8 @@ SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 SciMLLogging = "a6db7da4-7206-11f0-1eab-35f2a5dbe1d1"
 SymbolicIndexingInterface = "2efcf032-c050-4f8e-a9bb-153293bab1f5"
 
-[compat]Symbolics = "7.39.2"
+[compat]
+Symbolics = "7.39.2"
 
 AllocCheck = "0.2"
 ArrayInterface = "7.25.0"

--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,8 @@ SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 SciMLLogging = "a6db7da4-7206-11f0-1eab-35f2a5dbe1d1"
 SymbolicIndexingInterface = "2efcf032-c050-4f8e-a9bb-153293bab1f5"
 
-[compat]
+[compat]Symbolics = "7.39.2"
+
 AllocCheck = "0.2"
 ArrayInterface = "7.25.0"
 BenchmarkTools = "1"
@@ -32,6 +33,7 @@ Test = "1"
 julia = "1.10"
 
 [extras]
+Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 AllocCheck = "9b6a8646-10ed-4001-bbdc-1d2f46dfbb1a"
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 DAEProblemLibrary = "dfb8ca35-80a1-48ba-a605-84916a45b4f8"
@@ -43,4 +45,4 @@ SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["AllocCheck", "BenchmarkTools", "DAEProblemLibrary", "JLArrays", "ModelingToolkit", "NonlinearSolve", "SafeTestsets", "SciMLTesting", "Test"]
+test = ["Symbolics", "AllocCheck", "BenchmarkTools", "DAEProblemLibrary", "JLArrays", "ModelingToolkit", "NonlinearSolve", "SafeTestsets", "SciMLTesting", "Test"]


### PR DESCRIPTION
## Summary
- Force `Symbolics = "7.39.2"` so x86 CI resolves SymbolicUtils ≥4.46.4.
- Adds Symbolics as a test extra when it was only transitive via ModelingToolkit.

## Test plan
- [ ] x86 Core green
- [ ] Matching non-x86 Core still green

Made with [Cursor](https://cursor.com)