### PR TITLE
Add AirspeedVelocity benchmarking CI

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,29 @@
+name: Benchmark this PR
+
+on:
+  pull_request:
+    branches: [master]
+    paths-ignore: ['docs/**']
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ["1", "lts"]
+    env:
+      # Force consistent Julia depot path for self-hosted runners
+      JULIA_DEPOT_PATH: ~/.julia
+    steps:
+      - uses: MilesCranmer/AirspeedVelocity.jl@action-v1
+        with:
+          julia-version: ${{ matrix.version }}
+          script: "benchmark/benchmarks.jl"
+          extra-pkgs: ""
+          job-summary: true

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,0 +1,33 @@
+using DASSL, BenchmarkTools
+
+const SUITE = BenchmarkGroup()
+
+# Robertson DAE
+function dae_robertson!(resid, du, u, p, t)
+    resid[1] = du[1] + 0.04 * u[1] - 1.0e4 * u[2] * u[3]
+    resid[2] = du[2] - 0.04 * u[1] + 1.0e4 * u[2] * u[3] + 3.0e7 * u[2]^2
+    resid[3] = u[1] + u[2] + u[3] - 1.0
+    return nothing
+end
+u0 = [1.0, 0.0, 0.0]
+du0 = [-0.04, 0.04, 0.0]
+prob = DAEProblem(
+    dae_robertson!, du0, u0, (0.0, 10.0);
+    differential_vars = [true, true, false]
+)
+
+# =============================================================================
+# DASSL solves
+# =============================================================================
+
+SUITE["solve"] = BenchmarkGroup()
+
+SUITE["solve"]["robertson"] = @benchmarkable solve($prob, dassl())
+SUITE["solve"]["robertson_long"] = @benchmarkable solve(
+    $(
+        DAEProblem(
+            dae_robertson!, du0, u0, (0.0, 100.0);
+            differential_vars = [true, true, false]
+        )
+    ), dassl()
+)


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/benchmark.yml` running AirspeedVelocity on pull requests (Julia `1` and `lts`, 30 min timeout), following the OrdinaryDiffEq.jl setup.
- Adds `benchmark/benchmarks.jl` with a small `SUITE` covering representative workloads for this package.

The suite was verified locally in a fresh environment: it loads and all benchmarks run in ~10s.

#### Test plan

- [x] `run(SUITE)` locally: all benchmarks pass (~10s)
- [x] Runic formatting clean on `benchmark/benchmarks.jl`
- [ ] \"Benchmark this PR\" workflow triggers and completes on this PR

🤖 Generated with [Devin](https://devin.ai) (harness: devin 3000.10.21, model: SWE-2 High)
Session: local transcript /home/crackauc/sandbox/tmp_20260911_112052_59120/history_6a789c0b69c64ca3.md